### PR TITLE
#4 fix osx shortcut issue

### DIFF
--- a/node-webkit/app/assets/js/notedown.js
+++ b/node-webkit/app/assets/js/notedown.js
@@ -571,6 +571,15 @@ var notedown = new noteDown({
 //Read the notes saved.
 notedown.readNotesFromDisk();
 
+//Enable MenuBar and common key shortcuts 
+var nativeMenuBar = new gui.Menu({ type: "menubar" });
+try {
+    nativeMenuBar.createMacBuiltin("Notedown");
+    gui.Window.get().menu = nativeMenuBar;
+} catch (ex) {
+    console.log(ex.message);
+}
+
 //Show the window.
 gui.Window.get().show();
 


### PR DESCRIPTION
This is a fix for https://github.com/isdampe/Notedown/issues/4.

Just followed the advice from nw.js issue (https://github.com/nwjs/nw.js/issues/1955).
Fix worked just fine for me (OSX 10.9.5). I hope this is a proper position for the fix - don't hesitate to correct me. I can also do another PR if you tell me the correct position.

Unfortunately I didn't find an option to disable the menubar itself. Maybe this is necessary in order to support native OS shortcuts.