### PR TITLE
Save untitled document

### DIFF
--- a/node-webkit/app/assets/js/notedown.js
+++ b/node-webkit/app/assets/js/notedown.js
@@ -133,7 +133,14 @@ function noteDown( opts ) {
 		var content = notedown.elements.noteEditorContent.value;
 		var color = notedown.elements.noteEditorColor.value;
 
-		if ( title !== "" ) {
+		if ( (title !== "") || (content !== "") ) {
+
+			//If document has no title it will be saved as an "untitled document"
+			if ((content !== "") && (title === "")) {
+
+				title = "untitled document";
+				
+			}
 
 			//Can save.
 			if ( activeNoteId === -1 ) {
@@ -544,18 +551,18 @@ function noteDown( opts ) {
 			
 			//Check for valid json.
 			try {
-	        	var json = JSON.parse( buffer );
-	    	} catch (e) {
-	        	var json = -1;
-	    	}
+        var json = JSON.parse( buffer );
+    	} catch (e) {
+        var json = -1;
+    	}
 
-	    	if ( json !== -1 ) {
-	    		//Valid json.
-	    		notes = json;
-	    	} else {
-	    		//Invalid file.
-	    		alert("Your data file is corrupt. We're going to automatically right over this. If you want to back it up, you should do so before saving any notes. You can find the file here.\n\n" + notedown.opts.filePath );
-	    	}
+    	if ( json !== -1 ) {
+    		//Valid json.
+    		notes = json;
+    	} else {
+    		//Invalid file.
+    		alert("Your data file is corrupt. We're going to automatically right over this. If you want to back it up, you should do so before saving any notes. You can find the file here.\n\n" + notedown.opts.filePath );
+    	}
 
 		}
 

--- a/node-webkit/app/assets/js/notedown.js
+++ b/node-webkit/app/assets/js/notedown.js
@@ -544,18 +544,18 @@ function noteDown( opts ) {
 			
 			//Check for valid json.
 			try {
-        var json = JSON.parse( buffer );
-    	} catch (e) {
-        var json = -1;
-    	}
+	        	var json = JSON.parse( buffer );
+	    	} catch (e) {
+	        	var json = -1;
+	    	}
 
-    	if ( json !== -1 ) {
-    		//Valid json.
-    		notes = json;
-    	} else {
-    		//Invalid file.
-    		alert("Your data file is corrupt. We're going to automatically right over this. If you want to back it up, you should do so before saving any notes. You can find the file here.\n\n" + notedown.opts.filePath );
-    	}
+	    	if ( json !== -1 ) {
+	    		//Valid json.
+	    		notes = json;
+	    	} else {
+	    		//Invalid file.
+	    		alert("Your data file is corrupt. We're going to automatically right over this. If you want to back it up, you should do so before saving any notes. You can find the file here.\n\n" + notedown.opts.filePath );
+	    	}
 
 		}
 


### PR DESCRIPTION
This is a fix for https://github.com/isdampe/Notedown/issues/6.

Added a check for empty title but filled content in order to save a document with a default title ("untitled document").
I guess this behaviour is much better than losing the content ;)